### PR TITLE
fix: remove concurrency setting from e2e tests

### DIFF
--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -3,10 +3,6 @@ name: ci-e2e
 on:
   deployment_status:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}


### PR DESCRIPTION
When running in deployment_status, github.ref does not exist and is cancelled when run in parallel between PRs