### PR TITLE
refactor: タグページのパス構造をApp RouterのPage Groupsに適した形に変更

### DIFF
--- a/app/_features/articles/ArticleList.tsx
+++ b/app/_features/articles/ArticleList.tsx
@@ -1,4 +1,5 @@
 import { ArticleListItem } from "./ArticleListItem";
+import { tagLabelMap } from "./constants";
 import { getArticlesMeta } from "./getArticlesMeta";
 import type { TagEnum } from "./type";
 
@@ -13,7 +14,9 @@ export const ArticleList = ({ tag }: Props): JSX.Element => {
 
   return (
     <div className="blur-enter-content">
-      <h1 className="text-xl">All Writing</h1>
+      <h1 className="text-xl">
+        {tag ? tagLabelMap[tag] : "All Writing"}
+      </h1>
 
       <div className="mt-12 grid gap-6 blur-enter-content enter-step-80">
         {articlesMeta.map((article) => (

--- a/app/_features/articles/ArticleList.tsx
+++ b/app/_features/articles/ArticleList.tsx
@@ -1,9 +1,32 @@
+import { Link } from "@/app/_features/viewTransition/Link";
+import { cn } from "@/app/_utils/cn";
 import { ArticleListItem } from "./ArticleListItem";
 import { tagLabelMap } from "./constants";
 import { getArticlesMeta } from "./getArticlesMeta";
+import { tagList } from "./type";
 import type { TagEnum } from "./type";
 
-import type { JSX } from "react";
+import type { ComponentProps, JSX } from "react";
+
+type TagChipProps = {
+  href: string;
+  isActive: boolean;
+  label: string;
+} & Omit<ComponentProps<typeof Link>, "href" | "className">;
+
+const TagChip = ({ href, isActive, label, ...props }: TagChipProps) => (
+  <Link
+    href={href}
+    className={cn(
+      "inline-flex items-center rounded-md px-3 py-1 text-xs transition-colors whitespace-nowrap",
+      "border border-muted-foreground/20 hover:bg-accent",
+      isActive && "bg-accent hover:bg-accent/90",
+    )}
+    {...props}
+  >
+    {label}
+  </Link>
+);
 
 type Props = {
   tag?: TagEnum;
@@ -14,11 +37,23 @@ export const ArticleList = ({ tag }: Props): JSX.Element => {
 
   return (
     <div className="blur-enter-content">
-      <h1 className="text-xl">
-        {tag ? tagLabelMap[tag] : "All Writing"}
-      </h1>
+      <h1 className="text-xl">{tag ? tagLabelMap[tag] : "All Writing"}</h1>
 
-      <div className="mt-12 grid gap-6 blur-enter-content enter-step-80">
+      <div className="my-8 overflow-x-auto pb-2">
+        <div className="flex gap-2 flex-nowrap">
+          <TagChip href="/articles" isActive={!tag} label="All" />
+          {tagList.map((tagItem) => (
+            <TagChip
+              key={tagItem}
+              href={`/articles/tags/${tagItem}`}
+              isActive={tag === tagItem}
+              label={tagLabelMap[tagItem]}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-6 blur-enter-content enter-step-80">
         {articlesMeta.map((article) => (
           <ArticleListItem key={article.title} {...article} />
         ))}

--- a/app/articles/tags/[tag]/page.tsx
+++ b/app/articles/tags/[tag]/page.tsx
@@ -21,15 +21,11 @@ export default async function Page(props: Props) {
     notFound();
   }
   const tag = parsed.data;
-  const label = tagLabelMap[tag];
 
   return (
-    <div className="grid gap-8">
-      <h1 className="flex items-center gap-2 font-bold text-3xl">
-        <span>Articles - {label}</span>
-      </h1>
+    <main className="max-w-3xl mx-auto py-16 md:py-32 px-4 md:px-0">
       <ArticleList tag={tag} />
-    </div>
+    </main>
   );
 }
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -5,6 +5,7 @@
 The project is an established personal website/blog built with Next.js, React 19, and TypeScript. Based on the repository structure and recent commits, the site appears to be actively maintained with ongoing improvements to both content and functionality.
 
 Recent changes indicate work on:
+- Implementing a tag navigation list in the article listing page
 - UI adjustments for date display in article listings
 - Dependency updates via Renovate
 - Visual regression testing integration
@@ -27,9 +28,9 @@ The website includes several notable features:
 
 3. **Page Structure**
    - Home page with personal information
-   - Articles listing with pagination
+   - Articles listing with pagination and tag filtering navigation
    - Individual article pages with metadata
-   - Tag-based filtering
+   - Tag-based filtering and browsing
 
 4. **Technical Features**
    - RSS feed generation

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -41,6 +41,8 @@ The website appears to be a fully functioning personal site with blog capabiliti
 ### Recent Improvements
 
 Recent commits indicate:
+- Tag navigation list added to article listing page for easier content browsing
+- Unified layout between main article page and tag-specific pages
 - UI refinements for date display in article listings
 - Dependency updates via Renovate
 - Bug fixes and small improvements
@@ -58,6 +60,8 @@ The project appears to be using modern web technologies with recent migrations t
 - Focus on clean, readable typography
 - Implementation of view transitions for smoother navigation
 - Refinement of mobile experience
+- Enhanced content browsing with tag navigation elements
+- Consistent layout and styling across different page types
 
 ### Content Evolution
 - Regular additions of new articles

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -55,6 +55,10 @@ public/                     # Static assets
 3. **Command Menu Pattern**: Global menu for navigation and actions
 4. **View Transitions**: Smooth page transitions for improved UX
 5. **Consistent Typography**: Type scale using Tailwind's typography plugin
+6. **Navigation Patterns**:
+   - Tag-based navigation for content filtering
+   - Chip/badge UI elements for tag selection
+   - Consistent layout between related page types
 
 ## Implementation Patterns
 
@@ -84,6 +88,7 @@ public/                     # Static assets
    - Processing through Contentlayer
    - Rendering with React components
    - Enhancement with syntax highlighting and other features
+   - Tag-based browsing and filtering
 
 2. **Page Transition System**:
    - View Transitions API integration


### PR DESCRIPTION
## 概要
- App Routerのパス構造を最適化するために、タグページを`app/(pages)/articles/tags/[tag]`から`app/articles/tags/[tag]`に移動
- ArticleListコンポーネントを改善し、タグに応じたタイトル表示に対応
- ページレイアウトを他のページと統一

## テスト項目
- [ ] タグページの機能が正常に動作すること
- [ ] ページレイアウトが正しく表示されること
- [ ] ビルドが正常に完了すること

🤖 Generated with [Claude Code](https://claude.ai/code)