### PR TITLE
コンテンツ表示名を"All Writing"から"All Contents"に変更

### DIFF
--- a/app/_features/articles/ArticleList.tsx
+++ b/app/_features/articles/ArticleList.tsx
@@ -37,7 +37,7 @@ export const ArticleList = ({ tag }: Props): JSX.Element => {
 
   return (
     <div className="blur-enter-content">
-      <h1 className="text-xl">{tag ? tagLabelMap[tag] : "All Writing"}</h1>
+      <h1 className="text-xl">{tag ? tagLabelMap[tag] : "All Contents"}</h1>
 
       <div className="my-8 overflow-x-auto pb-2">
         <div className="flex gap-2 flex-nowrap">

--- a/app/_features/command/Command.tsx
+++ b/app/_features/command/Command.tsx
@@ -53,7 +53,7 @@ export function Command() {
             )}
             <CommandLinkItem href="/articles">
               <PenLine className="mr-2 h-4 w-4" />
-              <span>All Writing</span>
+              <span>All Contents</span>
             </CommandLinkItem>
             <CommandLinkItem href="/behavior">
               <PenLine className="mr-2 h-4 w-4" />

--- a/app/articles/[slug]/__tests__/page.e2e.ts
+++ b/app/articles/[slug]/__tests__/page.e2e.ts
@@ -34,13 +34,13 @@ test.describe("Command Palette", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible();
   });
 
-  test("Navigate to All Writing", async ({ page }) => {
+  test("Navigate to All Contents", async ({ page }) => {
     await setup(page, "/");
     await page.getByRole("button", { name: "Open command palette" }).click();
-    await page.getByRole("option", { name: "All Writing" }).click();
+    await page.getByRole("option", { name: "All Contents" }).click();
 
     await expect(page.getByRole("dialog")).not.toBeVisible();
-    await expect(page.getByRole("heading", { name: "All Writing" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "All Contents" })).toBeVisible();
   });
 
   test("Navigate to `Source of this site` on another tab", async ({ page }) => {
@@ -55,7 +55,7 @@ test.describe("Command Palette", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible();
   });
 
-  test("Navigate to All Writing with Enter key", async ({ page }) => {
+  test("Navigate to All Contents with Enter key", async ({ page }) => {
     await setup(page, "/");
     await page.locator("body").press("ControlOrMeta+k");
     await page.keyboard.press("ArrowDown");
@@ -63,7 +63,7 @@ test.describe("Command Palette", () => {
     await page.keyboard.press("Enter");
 
     await expect(page.getByRole("dialog")).not.toBeVisible();
-    await expect(page.getByRole("heading", { name: "All Writing" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "All Contents" })).toBeVisible();
   });
 
   test("Navigate to `Source of this site` with Enter key", async ({ page }) => {

--- a/app/articles/[slug]/_features/Article.tsx
+++ b/app/articles/[slug]/_features/Article.tsx
@@ -21,7 +21,7 @@ export const Article = ({ slug, handleNotFound }: Props) => {
         isEnabledUnderline
         className="text-zinc-700 dark:text-zinc-300"
       >
-        ← All Writing
+        ← All Contents
       </UniversalLink>
       <ArticleMetaDetail article={article} />
       <div className="mt-12 md:mt-16 w-full">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ export default function Page() {
           <div className="flex flex-col gap-1">
             <h3>
               <UniversalLink href="/articles" isEnabledUnderline>
-                All Writing
+                All Contents
               </UniversalLink>
             </h3>
             <p className="text-sm text-foreground-sub">


### PR DESCRIPTION
## Summary
- サイト内の「All Writing」という表示テキストを「All Contents」に変更しました
- 関連するテスト等も更新済みです

## Test plan
- 各ページで「All Contents」が正しく表示されることを確認
- コマンドパレットのテキストが変更されていることを確認 
- E2Eテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)