### PR TITLE
記事一覧ページの改善とWritingからContentsへの変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ axe-html-report/
 
 # pagefind
 public/search
+
+**/.claude/settings.local.json

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -1,10 +1,15 @@
 import type { Metadata } from "next";
 
-import { ArticleList } from "../_features";
+import { ArticleList, UniversalLink } from "../_features";
 
 export default function Page() {
   return (
     <main className="max-w-3xl mx-auto py-16 md:py-32 px-4 md:px-0">
+      <div className="mb-8 blur-enter-content">
+        <UniversalLink href="/" isEnabledUnderline className="text-zinc-700 dark:text-zinc-300">
+          ← Home
+        </UniversalLink>
+      </div>
       <ArticleList />
     </main>
   );


### PR DESCRIPTION
## 概要
- 記事一覧ページにホームに戻るリンクを追加
- "All Writing"を"All Contents"に変更（ブランチ名の通り）
- .gitignoreに.claude/settings.local.jsonを追加

## テスト項目
- 記事一覧ページのホームリンクが正常に動作することを確認
- "All Contents"の表示が適切に変更されていることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)