### PR TITLE
feat: ArticleListコンポーネントにホームリンクを追加し、ページ構造を簡素化

### DIFF
--- a/app/_features/articles/ArticleList.tsx
+++ b/app/_features/articles/ArticleList.tsx
@@ -7,6 +7,7 @@ import { tagList } from "./type";
 import type { TagEnum } from "./type";
 
 import type { ComponentProps, JSX } from "react";
+import { UniversalLink } from "../viewTransition";
 
 type TagChipProps = {
   href: string;
@@ -36,7 +37,12 @@ export const ArticleList = ({ tag }: Props): JSX.Element => {
   const articlesMeta = getArticlesMeta({ tag });
 
   return (
-    <div className="blur-enter-content">
+    <main className="max-w-3xl mx-auto py-16 md:py-32 px-4 md:px-0 blur-enter-content">
+      <div className="mb-8">
+        <UniversalLink href="/" isEnabledUnderline className="text-zinc-700 dark:text-zinc-300">
+          ← Home
+        </UniversalLink>
+      </div>
       <h1 className="text-xl">{tag ? tagLabelMap[tag] : "All Contents"}</h1>
 
       <div className="my-8 overflow-x-auto pb-2">
@@ -58,6 +64,6 @@ export const ArticleList = ({ tag }: Props): JSX.Element => {
           <ArticleListItem key={article.title} {...article} currentTag={tag} />
         ))}
       </div>
-    </div>
+    </main>
   );
 };

--- a/app/contents/page.tsx
+++ b/app/contents/page.tsx
@@ -1,18 +1,9 @@
 import type { Metadata } from "next";
 
-import { ArticleList, UniversalLink } from "../_features";
+import { ArticleList } from "../_features";
 
 export default function Page() {
-  return (
-    <main className="max-w-3xl mx-auto py-16 md:py-32 px-4 md:px-0">
-      <div className="mb-8 blur-enter-content">
-        <UniversalLink href="/" isEnabledUnderline className="text-zinc-700 dark:text-zinc-300">
-          ← Home
-        </UniversalLink>
-      </div>
-      <ArticleList />
-    </main>
-  );
+  return <ArticleList />;
 }
 
 export const metadata: Metadata = {

--- a/app/contents/tags/[tag]/page.tsx
+++ b/app/contents/tags/[tag]/page.tsx
@@ -22,11 +22,7 @@ export default async function Page(props: Props) {
   }
   const tag = parsed.data;
 
-  return (
-    <main className="max-w-3xl mx-auto py-16 md:py-32 px-4 md:px-0">
-      <ArticleList tag={tag} />
-    </main>
-  );
+  return <ArticleList tag={tag} />;
 }
 
 export const generateStaticParams = (): Params[] => {


### PR DESCRIPTION
- ArticleListにホームへのリンクを追加
- 不要な<main>タグを削除し、ArticleListの呼び出しを簡素化