### PR TITLE
chore: change Playwright reporter from html to list

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : "100%",
-  reporter: "html",
+  reporter: "list",
   use: {
     baseURL: process.env.BASE_URL || "http://localhost:3000",
     trace: "on-first-retry",


### PR DESCRIPTION
## Summary
- Playwrightのレポーターを`html`から`list`に変更
- テスト失敗時にサーバーが自動起動するのを防ぐ
- テスト結果はターミナルに表示されるように

## Test plan
- [ ] Playwrightテストを実行して、結果がターミナルに表示されることを確認
- [ ] テスト失敗時にサーバーが起動しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)