### PR TITLE
feat: add lockfile validation to lint scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint:tsc": "tsc",
     "lint:markuplint": "markuplint --problem-only \"**/*.tsx\"",
     "lint:knip": "knip",
+    "lint:lockfile": "pnpm install --frozen-lockfile",
     "lint:rulens": "rulens lint",
     "lint": "pnpm run '/^lint:.*/'",
     "fmt:biome-check": "biome check . --write --unsafe",


### PR DESCRIPTION
## Summary
- Add `lint:lockfile` script that runs `pnpm install --frozen-lockfile`
- This helps catch lockfile update oversights during the linting process

## Test plan
- [ ] Run `pnpm lint` to verify the new script is included
- [ ] Test that the script fails when lockfile is out of sync

🤖 Generated with [Claude Code](https://claude.ai/code)