### PR TITLE
chore: update pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     dependencies:
       '@contentlayer/source-remote-files':
         specifier: 0.3.4
-        version: 0.3.4(esbuild@0.25.0)
+        version: 0.3.4(esbuild@0.27.1)
       '@next/third-parties':
         specifier: 15.5.7
         version: 15.5.7(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
@@ -11025,7 +11025,7 @@ snapshots:
     dependencies:
       estree-util-is-identifier-name: 1.1.0
       estree-util-value-to-estree: 1.3.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       toml: 3.0.0
 
   remark-mdx@2.3.0:


### PR DESCRIPTION
## Summary
This PR updates the pnpm-lock.yaml to resolve dependency resolution issues that occurred during `pnpm install`.

## Changes
- Update @contentlayer/source-remote-files esbuild peer dependency from 0.25.0 to 0.27.1
- Update js-yaml from 4.1.0 to 4.1.1

## Test plan
- [x] pnpm install completes successfully
- [x] pnpm build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)