### PR TITLE
fix: aboutページのtitle設定を修正

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -21,11 +21,11 @@ export default async function Page(props: Props) {
 }
 
 export const generateStaticParams = (): Params[] =>
-  allAbouts.map((about) => ({ slug: about.href }));
+  allAbouts.map((about) => ({ slug: about.href.replace(/^\//, "") }));
 
 export const generateMetadata = async (props: Props): Promise<Metadata> => {
   const params = await props.params;
-  const title = allAbouts.find((about) => about.href === params.slug)?.title ?? "";
+  const title = allAbouts.find((about) => about.href === `/${params.slug}`)?.title ?? "";
 
   return { title, openGraph: { title }, twitter: { title } };
 };


### PR DESCRIPTION
## Summary
- aboutページ（`/behavior`等）でtitleが「 | Hirotaka Miyagi」のみになっていた問題を修正
- `generateMetadata`と`generateStaticParams`でのスラッシュ不一致を解消
- 既存パターン（Content.tsx）に統一

## Changes
- `app/[slug]/page.tsx`: 2行修正

## Test
- ✅ ビルド成功（62ページ生成）
- ✅ リント通過
- ✅ `/behavior` → `好む振る舞い | Hirotaka Miyagi`
- ✅ `/readme` → `取扱説明書 | Hirotaka Miyagi`
- ✅ `/resume` → `MH4GF / Hirotaka Miyagi / 宮城広隆 | Hirotaka Miyagi`

Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)