### PR TITLE
Fix RSS feed URLs to use absolute paths

### DIFF
--- a/app/(pages)/articles/feed/_features/getRssFeed.ts
+++ b/app/(pages)/articles/feed/_features/getRssFeed.ts
@@ -12,10 +12,11 @@ export const getRssFeed = (): string => {
   });
   const articlesMeta = getArticlesMeta({});
   for (const article of articlesMeta) {
+    const url = article.href.startsWith("http") ? article.href : `${siteInfo.url}${article.href}`;
     rss.item({
       title: article.title,
       description: "",
-      url: article.href,
+      url,
       date: article.publishedAt,
     });
   }


### PR DESCRIPTION
## Summary
Updated the RSS feed generation to properly handle both absolute and relative article URLs by constructing full URLs when needed.

## Key Changes
- Added logic to detect whether article URLs are already absolute (starting with "http")
- Construct full URLs by prepending the site base URL for relative paths
- Apply the resolved URL to the RSS feed item instead of the raw href value

## Implementation Details
The change ensures that RSS feed readers receive properly formatted absolute URLs. If an article's `href` is already an absolute URL, it's used as-is. Otherwise, it's combined with `siteInfo.url` to create a complete URL. This prevents broken links in RSS feed consumers while maintaining compatibility with both absolute and relative URL formats.

https://claude.ai/code/session_01ASdg1uQo1osxVtztNhhJ4Z