### PR TITLE
ci: drop redundant outer checkout from depcruise job

### DIFF
--- a/.github/workflows/setup-pr.yml
+++ b/.github/workflows/setup-pr.yml
@@ -12,7 +12,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: MH4GF/dependency-cruiser-report-action@885013e37581e3472385ffa93c821b3505336bc1 # v2.5.3
         with:
           package-manager: pnpm


### PR DESCRIPTION
## Summary
- `depcruise` ジョブの outer `actions/checkout@v6` を削除。`MH4GF/dependency-cruiser-report-action` が内部で checkout を行うため冗長だった。
- 2026-03 以降継続していた `remote: Duplicate header: "Authorization"` (HTTP 400) の根本対応。

## 原因
outer `actions/checkout@v6` は `includeIf.gitdir:...path` 方式で Authorization を設定するが、action が内部で呼ぶ `actions/checkout@v4` はこの新方式を認識できず cleanup に失敗する。その上で v4 が自前の extraheader を追加するため、fetch 時に Authorization ヘッダが 2 本送られ 400 になる。

outer checkout はそもそも他ステップから利用されておらず、action 自身のチェックアウトで十分なため削除。

## Test plan
- [ ] この PR の CI で `depcruise` ジョブが fetch エラーなく成功すること
- [ ] `depcruise` が PR コメントを正常に投稿すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)