### PR TITLE
fix(e2e): use webpack mode for dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:pagefind": "tsx ./scripts/pagefind.mts",
     "build:rulens": "rulens generate",
     "postbuild": "pnpm run build:pagefind",
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     "start": "next start",
     "test": "pnpm run '/^test:.*/'",
     "test:playwright": "playwright test",


### PR DESCRIPTION
## Summary
- Playwright webServer が起動する `npm run dev` が Next.js 16 のデフォルト Turbopack で動作し、`next-contentlayer` が注入する webpack config を検出して `ERROR: This build is using Turbopack, with a webpack config and no turbopack config.` で exit 1 → `Process from config.webServer was not able to start. Exit code: 1` で e2e が失敗していた
- `build` script は既に `next build --webpack` と明示しているため、それに揃えて `dev` も `next dev --webpack` に変更し、error を解消 (Next.js の error メッセージ自体が推奨する回避策)
- 初回発生 2026-04-07 以降、断続的に e2e が赤くなる症状の恒久対応

## Test plan
- [ ] ローカルで `pnpm dev` が webpack モードで正常起動することを確認 (検証済み: `▲ Next.js 16.x.x (webpack)` で起動)
- [ ] 本 PR の Vercel Preview デプロイ完了後、ci-e2e ワークフローが緑になることを確認
- [ ] `next-contentlayer` の記事データが dev 環境で引き続き正しく表示されること

## Out of scope
- `next-env.d.ts` が dev と build で異なる path を書き込み合う問題は別 PR で対応予定 (Next.js 公式推奨に従い `.gitignore` 化 + CI に `next typegen` step 追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)