### PR TITLE
chore: gitignore next-env.d.ts per Next.js recommendation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: MH4GF/shared-config/.github/composite-actions/setup-pnpm@e913199a8ddda05f1704f1c5fa0073cc8ce8d409 # main
       - run: pnpm build:contentlayer
+      - run: pnpm exec next typegen
       - run: pnpm lint
 
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage
 .next/
 out/
 build
+next-env.d.ts
 
 # misc
 .DS_Store

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- `next-env.d.ts` を `.gitignore` に追加し git の track を解除
- CI (`lint` job) で型チェック前に `pnpm exec next typegen` を実行するステップを追加

## Background
Next.js 16 の typed routes 機能は `next dev` と `next build` で `next-env.d.ts` の import パスが異なる (`./.next/dev/types/routes.d.ts` vs `./.next/types/routes.d.ts`) ため、両コマンドを交互に実行するとファイルが互いに上書きし合って git diff が揺れていた。

[Next.js 公式](https://nextjs.org/docs/app/api-reference/config/typescript) は `next-env.d.ts` を `.gitignore` に追加することを推奨しており、[`next typegen` CLI ドキュメント](https://nextjs.org/docs/app/api-reference/cli/next#next-typegen-options) は CI/CD で `next build` 前に `next typegen` で型ファイルを生成することを推奨している。本 PR はその推奨に追従する。

## Test plan
- [x] ローカルで `next-env.d.ts` を削除した状態から `pnpm exec next typegen` 実行 → ファイル再生成を確認
- [x] `pnpm lint:tsc` が通ることを確認
- [x] `git status --ignored` で `next-env.d.ts` が Ignored files として扱われることを確認
- [ ] CI (`lint` job の `next typegen` → `lint` 順序) が緑になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)