### PR TITLE
fix(seo): set canonical URL per route

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { allAbouts } from "contentlayer/generated";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { siteInfo } from "@/app/_utils";
 import { Content } from "./_features";
 
 interface Params {
@@ -27,5 +28,10 @@ export const generateMetadata = async (props: Props): Promise<Metadata> => {
   const params = await props.params;
   const title = allAbouts.find((about) => about.href === `/${params.slug}`)?.title ?? "";
 
-  return { title, openGraph: { title }, twitter: { title } };
+  return {
+    title,
+    alternates: { canonical: `${siteInfo.url}/${params.slug}` },
+    openGraph: { title },
+    twitter: { title },
+  };
 };

--- a/app/__tests__/canonical.e2e.ts
+++ b/app/__tests__/canonical.e2e.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+const cases = [
+  { path: "/", expected: "https://mh4gf.dev" },
+  { path: "/blog", expected: "https://mh4gf.dev/blog" },
+  {
+    path: "/blog/testing-markdown-renderer",
+    expected: "https://mh4gf.dev/blog/testing-markdown-renderer",
+  },
+  { path: "/media", expected: "https://mh4gf.dev/media" },
+  { path: "/behavior", expected: "https://mh4gf.dev/behavior" },
+  { path: "/resume", expected: "https://mh4gf.dev/resume" },
+  { path: "/tags/nextjs", expected: "https://mh4gf.dev/tags/nextjs" },
+];
+
+test.describe("canonical URL", () => {
+  for (const { path, expected } of cases) {
+    test(`${path} points to ${expected}`, async ({ page }) => {
+      await page.goto(path);
+      const href = await page.locator('link[rel="canonical"]').getAttribute("href");
+      expect(href).toBe(expected);
+    });
+  }
+});

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { getArticle } from "@/app/_features";
+import { siteInfo } from "@/app/_utils";
 import { Article } from "./_features";
 
 interface Params {
@@ -34,6 +35,7 @@ export const generateMetadata = async (props: Props): Promise<Metadata> => {
   return {
     title,
     description,
+    alternates: { canonical: `${siteInfo.url}/blog/${params.slug}` },
     openGraph: { title, description, ...(headingImage ? { images: headingImage } : undefined) },
     twitter: {
       title,

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { ArticleList, getAllTags, getBlogMeta } from "../_features";
+import { siteInfo } from "../_utils";
 
 export default function Page() {
   return (
@@ -10,4 +11,5 @@ export default function Page() {
 
 export const metadata: Metadata = {
   title: "Blog",
+  alternates: { canonical: `${siteInfo.url}/blog` },
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,9 +31,6 @@ export const metadata: Metadata = {
     site: twitter,
     creator: twitter,
   },
-  alternates: {
-    canonical: url,
-  },
   icons: [
     {
       rel: "icon",

--- a/app/media/page.tsx
+++ b/app/media/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { ArticleList, getAllTags, getMediaMeta } from "../_features";
+import { siteInfo } from "../_utils";
 
 export default function Page() {
   return (
@@ -10,4 +11,5 @@ export default function Page() {
 
 export const metadata: Metadata = {
   title: "Media",
+  alternates: { canonical: `${siteInfo.url}/media` },
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -102,4 +102,5 @@ export default function Page() {
 
 export const metadata: Metadata = {
   title: `About | ${siteInfo.siteName}`,
+  alternates: { canonical: siteInfo.url },
 };

--- a/app/tags/[tag]/page.tsx
+++ b/app/tags/[tag]/page.tsx
@@ -9,6 +9,7 @@ import {
   tagList,
   tagsSchema,
 } from "@/app/_features";
+import { siteInfo } from "@/app/_utils";
 
 interface Params {
   tag: string;
@@ -49,5 +50,10 @@ export const generateMetadata = async (props: Props): Promise<Metadata> => {
   }
   const label = tagLabelMap[parsed.data];
 
-  return { title: label, openGraph: { title: label }, twitter: { title: label } };
+  return {
+    title: label,
+    alternates: { canonical: `${siteInfo.url}/tags/${parsed.data}` },
+    openGraph: { title: label },
+    twitter: { title: label },
+  };
 };


### PR DESCRIPTION
## Summary
- root layout がサイトトップの URL を絶対値で `alternates.canonical` に設定しており、子ルートが全てそれを継承して `<link rel="canonical" href="https://mh4gf.dev/">` を出力していた
- Lighthouse の記事ページ SEO audit `canonical` が fail していた原因を解消
- root layout の canonical を削除し、トップ / `/blog` / `/blog/[slug]` / `/media` / `/[slug]` (behavior, resume) / `/tags/[tag]` の各ページで個別に `${siteInfo.url}${path}` を canonical に設定

## Test plan
- [x] `pnpm build` でプリレンダー HTML の canonical を確認
- [x] `next start` + curl で 7 ページの canonical を実機確認（全て自身の URL）
- [x] Playwright E2E `app/__tests__/canonical.e2e.ts` を追加、7 ケース全て pass
- [x] `pnpm test:vitest` / `pnpm run lint:tsc` / `lint:next` / `lint:knip` / `lint:depcruise` / `lint:markuplint` pass
- [ ] デプロイ後に記事ページ Lighthouse desktop の SEO audit `canonical` が pass に戻ることを確認

## Note
`pnpm run lint:biome` は `.claude/tmp/` 配下の lighthouse レポート JSON / `.mcp.json` の既存 untracked ファイルで失敗するが、本変更とは無関係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)