### PR TITLE
feat(symphony): tracker を GitHub Issues へ切り替える

### DIFF
--- a/.github/workflows/status-label-exclusivity.yml
+++ b/.github/workflows/status-label-exclusivity.yml
@@ -1,0 +1,37 @@
+name: status label exclusivity
+
+on:
+  issues:
+    types: [labeled]
+
+# Symphony の GitHub tracker は issue の status:* label を状態の SSoT として読む。
+# 1 issue が status:* を 2 つ以上持つと状態が曖昧になるため、label が付いた直後に
+# 他の status:* を剥がす。これにより人間は「新しい label を付ける」1 操作だけで
+# 状態遷移でき、モバイルからの操作が成立する。
+jobs:
+  normalize:
+    if: startsWith(github.event.label.name, 'status:')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Remove the other status labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+          KEEP: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+
+          gh api "repos/${REPO}/issues/${ISSUE}/labels" \
+            | jq -r --arg keep "${KEEP}" \
+              '.[].name | select(startswith("status:")) | select(. != $keep)' \
+            > stale-labels.txt
+
+          while IFS= read -r label; do
+            [ -n "${label}" ] || continue
+            encoded="$(jq -rn --arg l "${label}" '$l | @uri')"
+            gh api --method DELETE "repos/${REPO}/issues/${ISSUE}/labels/${encoded}"
+            echo "removed ${label}"
+          done < stale-labels.txt

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,11 +1,14 @@
 ---
 tracker:
-  kind: linear
-  project_slug: "ai-native-workspace-202646c35423"
-  api_key: $LINEAR_API_KEY
+  kind: github
+  repo: MH4GF/mysite
   active_states: ["Todo", "In Progress", "Merging", "Rework"]
-  terminal_states: ["Human Review", "Done", "Canceled", "Duplicate"]
-  required_labels: ["mysite"]
+  terminal_states: ["Done", "Canceled"]
+
+review_watch:
+  enabled: true
+  states: ["Human Review"]
+  on_conflict_state: "In Progress"
 
 workspace:
   root: /Users/hermes/.symphony/workspaces/mysite
@@ -48,7 +51,7 @@ MH4GF/mysite (Next.js App Router 製の個人サイト) の clone で作業す�
 ## ワークフロー手順
 
 - セッション起動直後に `symphony-workflow` スキルを呼ぶ。ステータスの振り分け / workpad 運用 / 実装 / レビュースイープ / `Human Review` 遷移 / マージまで、進行は全て同スキルの手順に従う
-- `symphony-workflow` スキルが利用できない環境では実装に入らない。Linear issue にブロッカーコメント (何が不足しているか / 解除に必要な人間の対応) を 1 件書き、issue を `Human Review` へ動かして終了する
+- `symphony-workflow` スキルが利用できない環境では実装に入らない。issue にブロッカーコメント (何が不足しているか / 解除に必要な人間の対応) を 1 件書き、issue を `Human Review` へ動かして終了する
 - 下の「本リポジトリ固有ルール」はスキルの共通手順を上書きする
 
 ## 本リポジトリ固有ルール


### PR DESCRIPTION
## 概要

Linear 無料プランの issue 上限に到達したため、Symphony の tracker を GitHub Issues へ切り替える。

設計の一次ソースは MH4GF/works の `agents/ai-native/specs/github-tracker-design.md`。adapter は MH4GF/symphony#6、skill 側の tracker 中立化は MH4GF/claude-code#61 でマージ済み。

## 変更

**`WORKFLOW.md`** の `tracker` 節を `kind: github` へ差し替える。

- `repo` が routing を兼ねるため `project_slug` と `required_labels` が不要になる
- 認証は `~/.hermes/bin/gh-app-token` から解決されるので `api_key` の宣言も不要
- `Human Review` を `active_states` にも `terminal_states` にも入れない。Symphony の pick up 対象から外しつつ `review_watch` の監視対象に残すため
- `review_watch` が works の conflict-watcher cron を置き換える。`Human Review` 滞留中の PR が conflict したら `In Progress` へ戻す

**`.github/workflows/status-label-exclusivity.yml`** を追加する。`status:*` が付いた直後に他の `status:*` を剥がし、状態が 1 つに定まることを保証する。人間はモバイルからでも「新しい label を付ける」1 操作で遷移できる。

## 状態モデル

| Symphony state | GitHub |
|---|---|
| Backlog | open / `status:*` なし |
| Todo | open + `status:todo` |
| In Progress | open + `status:in-progress` |
| Human Review | open + `status:human-review` |
| Merging | open + `status:merging` |
| Rework | open + `status:rework` |
| Done | closed (`completed`) |
| Canceled | closed (`not_planned`) |

label は seed 済み。PR 本文に `Closes #<number>` を書けばマージ時に issue が close され `Done` へ移る。

## 既存 issue

移行しない。Linear の過去分はそのまま参照でき、本切り替え以降の新規 issue から GitHub を使う。

## マージ順序

Mac Studio 上の symphony escript を再ビルドしてからマージする。`kind: github` を古いバイナリが読むと `unsupported_tracker_kind` で起動に失敗するため。
