### PR TITLE
fix(ci): status:* 排他化の同時実行で label が全消えする問題を直す

### DIFF
--- a/.github/workflows/status-label-exclusivity.yml
+++ b/.github/workflows/status-label-exclusivity.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    # 同一 issue へ短時間に 2 回 label が付くと、古い run が自分の KEEP を基準に
+    # 新しい label を剥がし、双方が消えて status:* がゼロになる。最新の run だけを
+    # 残す。
+    concurrency:
+      group: status-label-exclusivity-${{ github.event.issue.number }}
+      cancel-in-progress: true
     steps:
       - name: Remove the other status labels
         env:
@@ -24,7 +30,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh api "repos/${REPO}/issues/${ISSUE}/labels" \
+          labels_json="$(gh api "repos/${REPO}/issues/${ISSUE}/labels")"
+
+          # cancel-in-progress をすり抜けた古い run への保険。KEEP が既に剥がされて
+          # いるなら、この run の基準は古い。何もせず抜ける。
+          if ! printf '%s' "${labels_json}" \
+            | jq -e --arg keep "${KEEP}" 'any(.[]; .name == $keep)' > /dev/null; then
+            echo "skip: ${KEEP} is no longer on the issue"
+            exit 0
+          fi
+
+          printf '%s' "${labels_json}" \
             | jq -r --arg keep "${KEEP}" \
               '.[].name | select(startswith("status:")) | select(. != $keep)' \
             > stale-labels.txt


### PR DESCRIPTION
## 見つかった不具合

`status:*` 排他化 Action が同時実行されると、**`status:*` が両方剥がれて空になる**。

`issues: labeled` で 2 回発火し、それぞれが「自分の `KEEP` 以外の `status:*` を剥がす」を**実行時点のラベル一覧**に対して行うため。

| run | KEEP | 実行時に見えるラベル | 剥がすもの |
|---|---|---|---|
| 1 | `status:backlog` | 両方 | `status:human-review` |
| 2 | `status:human-review` | 両方 | `status:backlog` |

`status:*` がゼロの issue は `Backlog` 扱いになり、**Symphony に永久に拾われず静かに止まります**。人間が状態遷移を 2 回続けて操作した時に踏むので、実運用で起きます。

MH4GF/works#410 で再現し、MH4GF/works#411 で修正した内容を本 repo へ配る PR。

## 修正

**issue 単位の concurrency で最新 run だけ残す。**

```yaml
concurrency:
  group: status-label-exclusivity-${{ github.event.issue.number }}
  cancel-in-progress: true
```

**すり抜けた古い run は自ら抜ける。** 処理前に `KEEP` がまだ issue に付いているかを確認し、無ければ何もせず exit する。古い基準で新しいラベルを剥がすのを防ぐ。

API 呼び出しも 1 回にまとめた。

## 検証

`actionlint` clean。works 側の正本と同一内容。
