### PR TITLE
chore(symphony): move tracker.repo under tracker.provider

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,7 +1,8 @@
 ---
 tracker:
   kind: github
-  repo: MH4GF/mysite
+  provider:
+    repo: MH4GF/mysite
   active_states: ["Todo", "In Progress", "Merging", "Rework"]
   terminal_states: ["Done", "Canceled"]
 


### PR DESCRIPTION
## Why

MH4GF/symphony が upstream の tracker interface を取り込み (MH4GF/symphony#8)、GitHub tracker の設定キーが `tracker.provider.*` へ移行した。旧来の flat な `tracker.repo` は新ビルドでは読まれず、`{:error, :missing_github_repo}` で workflow が起動しない。

## What

`tracker.repo` を `tracker.provider.repo` へ移す。`active_states` / `terminal_states` / `review_watch` などその他の設定は変更なし。`status:*` ラベルで状態を持つモデルも従来どおり。

## 反映順序

この PR 単体では既存の Symphony は壊れない (hermes の canonical clone は repo-sync が 1 時間間隔で追従するため)。ただし clone が追従した時点で旧ビルドは設定を読めなくなる。

1. Mac Studio で symphony clone を pull して Elixir build を再実行する
2. 本 PR を merge する
3. hermes の canonical clone を pull する
4. LaunchDaemon を再起動する

`issue.identifier` が `#N` から `GH-N` へ変わるため、再起動前に `/Users/hermes/.symphony/workspaces/<workflow>/` の旧 workspace を掃除する。

## 検証

新ビルドに対して両方の設定形を通した。

```
provider.repo (新): :ok  provider=%{"repo" => "MH4GF/works"}
flat repo    (旧): {:error, :missing_github_repo}  provider=%{}
```
